### PR TITLE
Fix compressed pgm search

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: |
           if [[ "${{ matrix.compiler }}" == "gcc" ]]; then
-            export CC=gcc-8 CXX=g++-8
+            export CC=gcc CXX=g++
           else
             export CC=clang CXX=clang++
           fi

--- a/include/pgm/pgm_index_variants.hpp
+++ b/include/pgm/pgm_index_variants.hpp
@@ -204,7 +204,12 @@ public:
             }
 
             auto i = std::distance(level.keys.begin(), lo);
-            pos = std::min<size_t>(level(slopes_table, i, k), level.get_intercept(i + 1));
+
+            if ( i + 2 < level.keys.size() ) {
+                pos = std::min<size_t>(level(slopes_table, i, k), level.get_intercept(i + 1));
+            } else {
+                pos = level(slopes_table, i, k);
+            }
         }
 
         auto lo = PGM_SUB_EPS(pos, Epsilon);

--- a/include/pgm/pgm_index_variants.hpp
+++ b/include/pgm/pgm_index_variants.hpp
@@ -193,36 +193,37 @@ public:
 
         for (const auto &level : levels) {
             auto lo = level.keys.begin() + PGM_SUB_EPS(pos, EpsilonRecursive + 1);
+            auto hi = level.keys.begin() + PGM_ADD_EPS(pos, EpsilonRecursive, level.size());
 
             static constexpr size_t linear_search_threshold = 8 * 64 / sizeof(K);
             if constexpr (EpsilonRecursive <= linear_search_threshold) {
-                for (; *std::next(lo) <= key; ++lo)
-                    continue;
+                while (*lo <= k && lo < hi) {
+                    ++lo;
+                }
             } else {
-                auto hi = level.keys.begin() + PGM_ADD_EPS(pos, EpsilonRecursive, level.size());
-                auto it = std::upper_bound(lo, hi, k);
-                lo == level.keys.begin() ? it : std::prev(it);
+                lo = std::upper_bound(lo, hi, k);
+            }
+
+            assert(lo >= level.keys.begin());
+            if (lo > level.keys.begin()) {
+                --lo;
             }
 
             auto i = std::distance(level.keys.begin(), lo);
 
-            if ( i + 2 < level.keys.size() ) {
+            assert(i < level.size());
+
+            if ( level.size() > i + 1 ) {
                 pos = std::min<size_t>(level(slopes_table, i, k), level.get_intercept(i + 1));
             } else {
                 pos = level(slopes_table, i, k);
             }
         }
 
-        if (pos > n) {
-            pos = n;
-        }
+        pos = std::min<size_t>(pos, n);
 
         auto lo = PGM_SUB_EPS(pos, Epsilon);
         auto hi = PGM_ADD_EPS(pos, Epsilon, n);
-
-        assert(lo < n);
-        assert(hi <= n);
-        assert(lo < hi);
 
         return {pos, lo, hi};
     }

--- a/include/pgm/pgm_index_variants.hpp
+++ b/include/pgm/pgm_index_variants.hpp
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <cassert>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -212,8 +213,17 @@ public:
             }
         }
 
+        if (pos > n) {
+            pos = n;
+        }
+
         auto lo = PGM_SUB_EPS(pos, Epsilon);
         auto hi = PGM_ADD_EPS(pos, Epsilon, n);
+
+        assert(lo < n);
+        assert(hi <= n);
+        assert(lo < hi);
+
         return {pos, lo, hi};
     }
 


### PR DESCRIPTION
CompressedPGMIndex fails sometimes.

Here is assertion error got in benchmark.
```
benchmark: /home/d.tarasov/workspace/sirius/experiments2021/pgm/PGM-index/include/pgm/sdsl.hpp:7019: sdsl::int_vector<<anonymous> >::const_reference sdsl::int_vector<<anonymous> >::operator[](const size_type&) const [with unsigned char t_width = 0; sdsl::int_vector<<anonymous> >::const_reference = long unsigned int; sdsl::int_vector<<anonymous> >::size_type = long unsigned int]: Assertion `idx < this->size()' failed.
```

* posible out of bounds in linear search 
* I guess assignment was expected here:
```cpp
lo == level.keys.begin() ? it : std::prev(it);
```

* possible out of bounds in gettting intercept for the last segment
```cpp
level.get_intercept(i + 1)
```